### PR TITLE
fix: replace "pesudo" -> "pseudo"

### DIFF
--- a/2024-06-08/src/slides.md
+++ b/2024-06-08/src/slides.md
@@ -558,7 +558,7 @@ export default [
   }
 ]
 
-// (pesudo code for demo)
+// (pseudo code for demo)
 ```
 
 </div>

--- a/2024-06-13/src/slides.md
+++ b/2024-06-13/src/slides.md
@@ -486,7 +486,7 @@ export default [
   }
 ]
 
-// (pesudo code for demo)
+// (pseudo code for demo)
 ```
 
 </div>

--- a/2024-12-16/src/slides.md
+++ b/2024-12-16/src/slides.md
@@ -490,7 +490,7 @@ export default [
   }
 ]
 
-// (pesudo code for demo)
+// (pseudo code for demo)
 ```
 
 </div>

--- a/2025-05-23/src/slides.md
+++ b/2025-05-23/src/slides.md
@@ -660,7 +660,7 @@ export default [
   }
 ]
 
-// (pesudo code for demo)
+// (pseudo code for demo)
 ```
 
 </div>

--- a/2025-10-09/src/slides.md
+++ b/2025-10-09/src/slides.md
@@ -712,7 +712,7 @@ export default function MyPlugin(): Plugin {
     name: 'my-plugin',
     transform: { /* ... */ },
     devtools: {
-      /* pesudo-code for demo */
+      /* pseudo-code for demo */
       async setup({ rpc, views, docks }) {
         rpc.register({
           name: 'my-plugin:hello',

--- a/2025-10-25/src/slides.md
+++ b/2025-10-25/src/slides.md
@@ -794,7 +794,7 @@ export default function MyPlugin(): Plugin {
     name: 'my-plugin',
     transform: { /* ... */ },
     devtools: {
-      /* pesudo-code for demo */
+      /* pseudo-code for demo */
       async setup({ rpc, views, docks }) {
         rpc.register({
           name: 'my-plugin:hello',


### PR DESCRIPTION
### Description

Hey there,

first of all thank you for all the work on vite etc, I really enjoy using it so far and I guess many agree it's the best solution for bundling JS out there, especially with Rolldown coming along.

While watching [your talk about Vite Devtools on ViteConf 2025](https://youtu.be/tVd0JeSr8kg?si=-KNflhbgu8sLbddQ&t=1375) I realized you write (and say) "pesudo" instead of "pseudo" (spoken like "zudo", I guess).

I guess things like that happen all the time when mostly reading about stuff and not hearing it pronounced that often. In the end it doesn't really matter, but I just wanted to let you know and I replaced it in your slides. I hope that's okay.

### Linked Issues


### Additional context

